### PR TITLE
add didUpdateBeacon

### DIFF
--- a/BRM/BRMEddystoneReceiveManager.h
+++ b/BRM/BRMEddystoneReceiveManager.h
@@ -134,6 +134,7 @@ typedef NS_ENUM(NSUInteger, BRMFrameType) {
 @protocol BRMEddystoneReceiveDelegate <NSObject>
 @optional
 - (void)didRangeBeacons:(NSArray *)beacons;
+- (void)didUpdateBeacon:(BRMEddystoneBeacon *)beacon;
 - (void)didUpdateEnterUIDBeacon:(BRMEddystoneUIDBeacon *)brmUIDBeacon;
 - (void)didUpdateEnterURLBeacon:(BRMEddystoneURLBeacon *)brmURLBeacon;
 - (void)didUpdateEnterTLMBeacon:(BRMEddystoneTLMBeacon *)brmTLMBeacon;

--- a/BRM/BRMEddystoneReceiveManager.m
+++ b/BRM/BRMEddystoneReceiveManager.m
@@ -415,6 +415,10 @@
 
         [self enterBeacon:eddystoneBeacon];
     }
+    
+    if ([_delegate respondsToSelector:@selector(didUpdateBeacon:)]) {
+        [_delegate didUpdateBeacon:sameBeacon];
+    }
 }
 
 - (CBUUID *)getEddystoneServiceID {


### PR DESCRIPTION
Its currently very difficult to monitor a specific beacon for tlm (or distance) changes because didRangeBeacons is arbitrarily called on a timer, not on beacon update. Ive simply added didUpdateBeacon here, though I feel didRangeBeacons should probably be deprecated eventually.

Thanks for a great library.
